### PR TITLE
InputStream#readAllBytes() should receive no premature EOS

### DIFF
--- a/utils/src/main/java/software/amazon/awssdk/utils/async/InputStreamSubscriber.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/async/InputStreamSubscriber.java
@@ -102,6 +102,9 @@ public final class InputStreamSubscriber extends InputStream implements Subscrib
 
     @Override
     public int read(byte[] bytes, int off, int len) {
+        if (len == 0) {
+            return 0;
+        }
         ByteBuffer byteBuffer = ByteBuffer.wrap(bytes, off, len);
         TransferResult transferResult = delegate.blockingTransferTo(byteBuffer);
         int dataTransferred = byteBuffer.position() - off;


### PR DESCRIPTION
A `read`-call with `len == 0` happens here:
https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/java/io/InputStream.java#L396

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
